### PR TITLE
Improve CI workflow triggers and fix pnpm cache configuration

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,12 +2,14 @@ name: docker-build
 
 on:
   workflow_run:
-    workflows: [web]
+    workflows: [test, web]
+    branches: [master]
     types:
       - completed
 
 jobs:
   docker-build:
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,14 @@ on:
       - '**/*.go'
       - 'go.mod'
       - 'go.sum'
+      - '.github/workflows/test.yml'
   pull_request:
     branches: [master]
     paths:
       - '**/*.go'
       - 'go.mod'
       - 'go.sum'
+      - '.github/workflows/test.yml'
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,16 @@ name: test
 on:
   push:
     branches: [master]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
   pull_request:
     branches: [master]
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
 
 jobs:
   test:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -4,10 +4,12 @@ on:
     branches: [master]
     paths:
       - 'web/**'
+      - '.github/workflows/web.yml'
   pull_request:
     branches: [master]
     paths:
       - 'web/**'
+      - '.github/workflows/web.yml'
 
 jobs:
   lint:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,9 +1,13 @@
 name: web
 on:
-  workflow_run:
-    workflows: [test]
-    types:
-      - completed
+  push:
+    branches: [master]
+    paths:
+      - 'web/**'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'web/**'
 
 jobs:
   lint:
@@ -15,14 +19,11 @@ jobs:
       - uses: pnpm/action-setup@v6
         with:
           version: 10
-          cache: true
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        run: echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT
-        working-directory: ./web
+          cache: 'pnpm'
+          cache-dependency-path: web/pnpm-lock.yaml
       - name: pnpm install
         run: pnpm install --frozen-lockfile
         working-directory: ./web

--- a/web/src/views/Search.vue
+++ b/web/src/views/Search.vue
@@ -102,8 +102,7 @@ const searchPageUrl = (): string => {
 const tweetFoundUrl = (route: readonly string[]): string =>
   buildTweetUrl(t('message.tweetFind', { wordFrom: props.wordFrom, wordTo: props.wordTo, length: `${route.length - 1}` }), searchPageUrl());
 
-const tweetNotFoundUrl = (): string =>
-  buildTweetUrl(t('message.tweetNotFound', { wordFrom: props.wordFrom, wordTo: props.wordTo }), searchPageUrl());
+const tweetNotFoundUrl = (): string => buildTweetUrl(t('message.tweetNotFound', { wordFrom: props.wordFrom, wordTo: props.wordTo }), searchPageUrl());
 
 onMounted(search);
 watch(() => [props.wordFrom, props.wordTo], search);


### PR DESCRIPTION
## Summary

- `test` and `web` workflows: `workflow_run` トリガーから `push`/`pull_request` トリガーに変更し、`paths` フィルタを追加
- `docker-build` workflow: `test` と `web` 両方の完了をトリガーに追加し、`success` 時のみビルドするよう `if` 条件を追加
- pnpm キャッシュの設定を `pnpm/action-setup` の `cache: true` から `actions/setup-node` の `cache: 'pnpm'` + `cache-dependency-path` に修正

## Test plan

- [ ] PR マージ後、Goファイル変更時に `test` workflow が動くことを確認
- [ ] PR マージ後、`web/` 変更時に `web` workflow が動くことを確認
- [ ] PR マージ後、`test` または `web` 成功後に `docker-build` が動くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)