### PR TITLE
Switch app image to bind-mount data volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,9 @@
 *.dll
 *.so
 *.dylib
-/build/
+/build/gen
+/build/web
+/build/bench
 
 # Test binary, build with `go test -c`
 *.test

--- a/README.md
+++ b/README.md
@@ -47,6 +47,52 @@ You will find 4 files in current directory:
 - page.dat
 - link.dat
 
+For English:
+
+```console
+$ mkdir -p en
+$ ./build/gen \
+-lang en \
+-ip /path/to/enwiki-YYYYMMDD-page.sql.gz \
+-il /path/to/enwiki-YYYYMMDD-pagelinks.sql.gz \
+-ilt /path/to/enwiki-YYYYMMDD-linktarget.sql.gz \
+-o en/
+```
+
+For Japanese:
+
+```console
+$ mkdir -p ja
+$ ./build/gen \
+-lang ja \
+-ip /path/to/jawiki-YYYYMMDD-page.sql.gz \
+-il /path/to/jawiki-YYYYMMDD-pagelinks.sql.gz \
+-ilt /path/to/jawiki-YYYYMMDD-linktarget.sql.gz \
+-o ja/
+```
+
+# How to run with Docker
+
+Build the app image:
+
+```console
+$ make image
+```
+
+Run with the generated `en/` and `ja/` directories mounted:
+
+```console
+$ docker run \
+-v $(pwd)/ja:/data/ja \
+-v $(pwd)/en:/data/en \
+-e JA=/data/ja/config.json \
+-e EN=/data/en/config.json \
+-p 8080:8080 \
+mtgto/pediaroute:latest
+```
+
+The app will be available at http://localhost:8080 .
+
 # License
 
 GPL v3

--- a/build/package/app/Dockerfile
+++ b/build/package/app/Dockerfile
@@ -17,8 +17,9 @@ COPY --from=asset /node/dist ./cmd/web/assets
 COPY internal ./internal
 RUN make build/web
 
-FROM mtgto/pediaroute-data:latest
+FROM gcr.io/distroless/base-debian13
 WORKDIR /app
 COPY --from=app /go/src/github.com/mtgto/pediaroute-go/build/web .
+VOLUME ["/data"]
 ENV JA=/data/ja/config.json EN=/data/en/config.json
 ENTRYPOINT ["/app/web"]


### PR DESCRIPTION
## Summary

- Replace `mtgto/pediaroute-data:latest` (~7 GB) as the base image of the app Dockerfile with `gcr.io/distroless/base-debian13`, making the app image lightweight (tens of MB)
- Wikipedia data files (`ja/`, `en/`) are now provided at runtime via a bind mount at `/data` instead of being baked into the image
- Narrow the blanket `/build/` `.gitignore` entry to specific compiled binaries (`build/gen`, `build/web`, `build/bench`) so Dockerfiles under `build/package/` are tracked normally
- Add documentation to README covering data generation for both languages and how to run locally with Docker

## Motivation

Storing 7 GB of Wikipedia data inside a Docker image on Docker Hub has high transfer cost and slows down CI builds (which had to pull the full data image on every run). Data updates are infrequent, so managing data separately as a host directory that is bind-mounted at container startup is a simpler and cheaper approach.

## How to run

```console
# Transfer data to the server
rsync -avz ja/ en/ user@host:/opt/pediaroute-data/

# Start the container
docker run -d --name pediaroute \
  -v /opt/pediaroute-data:/data \
  -e JA=/data/ja/config.json \
  -e EN=/data/en/config.json \
  -p 8080:8080 \
  --restart unless-stopped \
  mtgto/pediaroute:latest
```

## Test plan

- [ ] `make image` builds successfully without pulling `mtgto/pediaroute-data`
- [ ] `docker run` with local `ja/` and `en/` bind-mounted starts and serves correctly at http://localhost:8080
- [ ] Verify image size is significantly smaller than before (`docker images mtgto/pediaroute`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)