### PR TITLE
Add Wikipedia dump version tracking and /api/info endpoint

### DIFF
--- a/cmd/gen/main.go
+++ b/cmd/gen/main.go
@@ -16,6 +16,7 @@ func main() {
 		pageLinkFile      = flag.String("il", "", "File path of pagelinks.sql.gz")
 		linktargetSQLFile = flag.String("ilt", "", "File path of linktarget.sql.gz (new MediaWiki format)")
 		outDir            = flag.String("o", "", "Output directory")
+		version           = flag.String("version", "", "Version of Wikipedia dump (YYYYMMDD format, e.g. 20250101)")
 	)
 	flag.Parse()
 	if fileMode, err := os.Stat(*pageFile); err != nil || !fileMode.Mode().IsRegular() {
@@ -40,5 +41,5 @@ func main() {
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
-	gen.Run(*language, *pageFile, *pageLinkFile, *linktargetSQLFile, *outDir)
+	gen.Run(*language, *pageFile, *pageLinkFile, *linktargetSQLFile, *outDir, *version)
 }

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -48,6 +48,7 @@ func main() {
 		englishConfigFile = &configFile
 	}
 
+	languagesMeta := make(map[string]*core.Language)
 	for lang, langFile := range map[string]string{"ja": *japaneseConfigFile, "en": *englishConfigFile} {
 		language, err := core.LoadLanguage(langFile)
 		if err != nil {
@@ -62,6 +63,7 @@ func main() {
 			log.Printf("Failed to load for lang %v: %v", lang, err)
 		} else {
 			wikipedias[lang] = wikipedia
+			languagesMeta[lang] = language
 		}
 		log.Printf("Loaded for language %v\n", lang)
 	}
@@ -77,6 +79,29 @@ func main() {
 	http.Handle("/", fileServer)
 	http.Handle("/about", http.StripPrefix("/about", fileServer))
 	http.Handle("/search", http.StripPrefix("/search", fileServer))
+
+	type LanguageInfo struct {
+		PageCount uint32 `json:"page_count"`
+		LinkCount uint64 `json:"link_count"`
+		Version   string `json:"version"`
+	}
+
+	http.HandleFunc("/api/info", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Not Found", http.StatusNotFound)
+			return
+		}
+		result := make(map[string]LanguageInfo)
+		for lang, meta := range languagesMeta {
+			result[lang] = LanguageInfo{
+				PageCount: meta.PageCount,
+				LinkCount: meta.LinkCount,
+				Version:   meta.Version,
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(result)
+	})
 
 	type Pair struct {
 		From string `json:"from"`

--- a/internal/app/core/core.go
+++ b/internal/app/core/core.go
@@ -16,6 +16,7 @@ type Language struct {
 	TitleFile string `json:"title_file"`
 	LinkCount uint64 `json:"link_count"`
 	LinkFile  string `json:"link_file"`
+	Version   string `json:"version"` // YYYYMMDD
 }
 
 type Page struct {

--- a/internal/app/gen/gen.go
+++ b/internal/app/gen/gen.go
@@ -61,12 +61,13 @@ func lookupIndex[K cmp.Ordered](idx []indexEntry[K], key K) (uint32, bool) {
 	return 0, false
 }
 
-func Run(languageId, pageSQLFile, pageLinkSQLFile, linktargetSQLFile, outDir string) error {
+func Run(languageId, pageSQLFile, pageLinkSQLFile, linktargetSQLFile, outDir, version string) error {
 	language := core.Language{
 		Id:        languageId,
 		PageFile:  "page.dat",
 		TitleFile: "title.dat",
 		LinkFile:  "link.dat",
+		Version:   version,
 	}
 	var pages []page
 	pageFile := path.Join(outDir, language.PageFile)

--- a/internal/app/gen/gen_test.go
+++ b/internal/app/gen/gen_test.go
@@ -155,7 +155,7 @@ func TestRun(t *testing.T) {
 		"INSERT INTO `pagelinks` VALUES (1,0,'B',0),(1,0,'C',0),(2,0,'C',0),(4,0,'A',0),(1,0,'NoSuchPage',0)")
 	outDir := t.TempDir()
 
-	if err := Run("test", pageSQLFile, pageLinkSQLFile, "", outDir); err != nil {
+	if err := Run("test", pageSQLFile, pageLinkSQLFile, "", outDir, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -243,7 +243,7 @@ func TestRunNewFormat(t *testing.T) {
 		"INSERT INTO `pagelinks` VALUES (1,0,20),(1,0,30),(2,0,30),(4,0,10),(1,0,999)")
 	outDir := t.TempDir()
 
-	if err := Run("test", pageSQLFile, pageLinkSQLFile, linktargetSQLFile, outDir); err != nil {
+	if err := Run("test", pageSQLFile, pageLinkSQLFile, linktargetSQLFile, outDir, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -289,7 +289,7 @@ func TestRunMultipleStatements(t *testing.T) {
 			"INSERT INTO `pagelinks` VALUES (2,0,'C',0);")
 	outDir := t.TempDir()
 
-	if err := Run("test", pageSQLFile, pageLinkSQLFile, "", outDir); err != nil {
+	if err := Run("test", pageSQLFile, pageLinkSQLFile, "", outDir, ""); err != nil {
 		t.Fatal(err)
 	}
 

--- a/web/src/views/Home.vue
+++ b/web/src/views/Home.vue
@@ -35,14 +35,38 @@
         </p>
       </div>
     </article>
+    <footer v-if="currentStats">
+      <p>
+        {{ locale === 'ja' ? '収録' : 'Index:' }} {{ currentStats.page_count.toLocaleString() }} {{ locale === 'ja' ? '記事' : 'articles' }} ·
+        {{ locale === 'ja' ? 'リンク数' : 'Links:' }} {{ currentStats.link_count.toLocaleString() }} · {{ locale === 'ja' ? '版' : 'Version:' }}
+        {{ currentStats.version || '...' }}
+      </p>
+    </footer>
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { useMainStore } from '../store';
 import { useI18n } from 'vue-i18n';
 import { useRouter } from 'vue-router';
+
+interface LangInfo {
+  page_count: number;
+  link_count: number;
+  version: string;
+}
+
+const langInfoMap = ref<Record<string, LangInfo>>({});
+
+onMounted(async () => {
+  await fetch('/api/info')
+    .then((r) => r.json())
+    .then((data: Record<string, LangInfo>) => {
+      langInfoMap.value = data;
+    })
+    .catch(console.error);
+});
 
 const state = useMainStore();
 const { t, locale } = useI18n();
@@ -50,6 +74,7 @@ const router = useRouter();
 
 const wordFrom = computed(() => state.wordFrom);
 const wordTo = computed(() => state.wordTo);
+const currentStats = computed(() => langInfoMap.value[locale.value]);
 
 const chooseEnglish = () => {
   locale.value = 'en';


### PR DESCRIPTION
## Summary

- `Language` 構造体と `config.json` に `version` フィールド（YYYYMMDD形式）を追加
- `gen` コマンドに `-version` フラグを追加し、データ取り込み時にダンプ日付を指定可能に
- Web サーバーに `/api/info` エンドポイントを追加し、言語ごとのページ数・リンク数・バージョンを JSON で返す
- フロントエンドの Home ページでマウント時に `/api/info` を fetch し、動的に表示

## Test plan

- [ ] `./gen -lang ja -ip page.sql.gz -il pagelinks.sql.gz -o ./ja -version 20250101` を実行し、`ja/config.json` に `"version": "20250101"` が含まれることを確認
- [ ] Web サーバー起動後 `curl http://localhost:9000/api/info` が `{"en":{...},"ja":{...}}` を返すことを確認
- [ ] フロントエンドでページ数・リンク数・バージョンが表示されること、EN/JA 切り替えで値が更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)