### PR TITLE
Switch CI runners to ubuntu-slim with timeout and bash defaults

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,32 +4,37 @@ on:
   push:
     branches: [master]
     paths:
-      - '**/*.go'
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/test.yml'
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/test.yml"
   pull_request:
     branches: [master]
     paths:
-      - '**/*.go'
-      - 'go.mod'
-      - 'go.sum'
-      - '.github/workflows/test.yml'
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/test.yml"
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-go@v6
-      with:
-        go-version: 1.26
-    - uses: actions/cache@v5
-      id: cache
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - name: test
-      run: make test
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: 1.26
+      - uses: actions/cache@v5
+        id: cache
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: test
+        run: make test

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,20 +1,26 @@
 name: web
+
 on:
   push:
     branches: [master]
     paths:
-      - 'web/**'
-      - '.github/workflows/web.yml'
+      - "web/**"
+      - ".github/workflows/web.yml"
   pull_request:
     branches: [master]
     paths:
-      - 'web/**'
-      - '.github/workflows/web.yml'
+      - "web/**"
+      - ".github/workflows/web.yml"
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
+    timeout-minutes: 10
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
@@ -24,7 +30,7 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: 'pnpm'
+          cache: "pnpm"
           cache-dependency-path: web/pnpm-lock.yaml
       - name: pnpm install
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

- `ubuntu-latest` から `ubuntu-slim` に変更（Node.js・Git・make など必要なツールはすべて含まれているため問題なし）
- ジョブに `timeout-minutes: 10` を追加（通常の実行は30秒以内のため余裕を持って10分に設定）
- `defaults.run.shell: bash` を追加し、シェルステップが `bash --noprofile --norc -eo pipefail` で実行されるように設定

## Test plan

- [ ] web ワークフローが ubuntu-slim 上で正常に完了することを確認
- [ ] test ワークフローが ubuntu-slim 上で正常に完了することを確認
- [ ] 10分以内にジョブが完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)