### PR TITLE
Add /api/related endpoint for Wikipedia page name suggestions

### DIFF
--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -149,6 +149,32 @@ func main() {
 		}
 	})
 
+	http.HandleFunc("/api/related", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "Not Found", http.StatusNotFound)
+			return
+		}
+		lang := r.FormValue("lang")
+		title := r.FormValue("title")
+		if len([]rune(title)) < 2 {
+			http.Error(w, "Bad Request", http.StatusBadRequest)
+			return
+		}
+		wikipedia, ok := wikipedias[lang]
+		if !ok {
+			http.Error(w, "Not Found", http.StatusNotFound)
+			return
+		}
+		titles, err := wikipedia.RelatedPages(title, 10)
+		if err != nil {
+			log.Printf("Error while get related pages: %v\n", err)
+			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(titles)
+	})
+
 	http.HandleFunc("/api/random", func (w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodGet {
 			lang := r.FormValue("lang")

--- a/internal/app/web/testdata/title_related.dat
+++ b/internal/app/web/testdata/title_related.dat
@@ -1,0 +1,1 @@
+AppleApplicationApricotBanana

--- a/internal/app/web/web.go
+++ b/internal/app/web/web.go
@@ -74,6 +74,30 @@ func (w *Wikipedia) GetRandomPage() (string, error) {
 	}
 }
 
+func (w *Wikipedia) RelatedPages(word string, limit int) ([]string, error) {
+	lowerWord := strings.ToLower(word)
+	index := sort.Search(len(w.pages), func(i int) bool {
+		t, err := w.title(w.pages[i])
+		if err != nil {
+			log.Printf("Error while RelatedPages: %v", err)
+		}
+		return strings.ToLower(t) >= lowerWord
+	})
+	results := make([]string, 0, limit)
+	for i := index; i < len(w.pages) && len(results) < limit; i++ {
+		t, err := w.title(w.pages[i])
+		if err != nil {
+			log.Printf("Error while RelatedPages: %v", err)
+			continue
+		}
+		if !strings.HasPrefix(strings.ToLower(t), lowerWord) {
+			break
+		}
+		results = append(results, t)
+	}
+	return results, nil
+}
+
 func (w *Wikipedia) generateWordSet(word string) map[uint32]struct{} {
 	lowercaseWord := strings.ToLower(word)
 	set := make(map[uint32]struct{}, 0)

--- a/internal/app/web/web_test.go
+++ b/internal/app/web/web_test.go
@@ -53,3 +53,54 @@ func TestSearch(t *testing.T) {
 	testSearch("A", "F", []string{})
 	testSearch("AA", "B", []string{})
 }
+
+func TestRelatedPages(t *testing.T) {
+	// Titles sorted by lowercase: "Apple"(0-4), "Application"(5-15), "Apricot"(16-22), "Banana"(23-28)
+	pages := []core.Page{
+		{Id: 0, TitleOffset: 0, TitleLength: 5},
+		{Id: 1, TitleOffset: 5, TitleLength: 11},
+		{Id: 2, TitleOffset: 16, TitleLength: 7},
+		{Id: 3, TitleOffset: 23, TitleLength: 6},
+	}
+	titleFile, err := os.Open("testdata/title_related.dat")
+	if err != nil {
+		t.Fatalf("Failed to open title data file: %v\n", err)
+	}
+	linkFile, err := os.Open("testdata/link.dat")
+	if err != nil {
+		t.Fatalf("Failed to open link data: %v\n", err)
+	}
+	w := Wikipedia{pages: pages, titleFile: titleFile, linkFile: linkFile}
+
+	tests := []struct {
+		word     string
+		limit    int
+		expected []string
+	}{
+		{"App", 10, []string{"Apple", "Application"}},
+		{"Appl", 10, []string{"Apple", "Application"}},
+		{"Apple", 10, []string{"Apple"}},
+		{"apr", 10, []string{"Apricot"}}, // case-insensitive
+		{"A", 10, []string{"Apple", "Application", "Apricot"}},
+		{"B", 10, []string{"Banana"}},
+		{"C", 10, []string{}},
+		{"App", 1, []string{"Apple"}}, // limit
+	}
+
+	for _, tt := range tests {
+		result, err := w.RelatedPages(tt.word, tt.limit)
+		if err != nil {
+			t.Errorf("RelatedPages(%q, %d) returned error: %v", tt.word, tt.limit, err)
+			continue
+		}
+		if len(result) != len(tt.expected) {
+			t.Errorf("RelatedPages(%q, %d) = %v, want %v", tt.word, tt.limit, result, tt.expected)
+			continue
+		}
+		for i, got := range result {
+			if got != tt.expected[i] {
+				t.Errorf("RelatedPages(%q, %d)[%d] = %q, want %q", tt.word, tt.limit, i, got, tt.expected[i])
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add `GET /api/related?lang=ja&title=東京` that returns up to 10 Wikipedia page titles matching a given prefix
- Uses binary search on the already-sorted pages array (O(log N)), no additional data structures needed
- Case-insensitive prefix matching; minimum 2 runes required (400 otherwise); unknown lang returns 404
- Add `RelatedPages(word string, limit int) ([]string, error)` method to `Wikipedia` struct

## Test plan

- [ ] `go test ./internal/app/web/` passes (`TestRelatedPages` covers prefix match, case-insensitivity, exact match, and limit)
- [ ] `curl "http://localhost:9000/api/related?lang=ja&title=東京"` returns JSON array of up to 10 page titles
- [ ] 1-character input → 400 Bad Request
- [ ] Unknown `lang` → 404 Not Found

🤖 Generated with [Claude Code](https://claude.com/claude-code)