### PR TITLE
Fix concurrent file access in forwardLinks/backwardLinks using ReadAt

### DIFF
--- a/internal/app/web/web.go
+++ b/internal/app/web/web.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"bytes"
 	"encoding/binary"
 	"errors"
 	"github.com/mtgto/pediaroute-go/internal/app/core"
@@ -208,26 +209,24 @@ func (w *Wikipedia) search(start, goal *map[uint32]struct{}, depth int) ([]uint3
 }
 
 func (w *Wikipedia) forwardLinks(page core.Page) ([]uint32, error) {
-	links := make([]uint32, page.ForwardLinkLength, page.ForwardLinkLength)
-	_, err := w.linkFile.Seek(int64(page.ForwardLinkIndex)*4, 0)
-	if err != nil {
+	links := make([]uint32, page.ForwardLinkLength)
+	buf := make([]byte, int(page.ForwardLinkLength)*4)
+	if _, err := w.linkFile.ReadAt(buf, int64(page.ForwardLinkIndex)*4); err != nil {
 		return nil, err
 	}
-	err = binary.Read(w.linkFile, binary.LittleEndian, links)
-	if err != nil {
+	if err := binary.Read(bytes.NewReader(buf), binary.LittleEndian, &links); err != nil {
 		return nil, err
 	}
 	return links, nil
 }
 
 func (w *Wikipedia) backwardLinks(page core.Page) ([]uint32, error) {
-	links := make([]uint32, page.BackwardLinkLength, page.BackwardLinkLength)
-	_, err := w.linkFile.Seek(int64(page.BackwardLinkIndex)*4, 0)
-	if err != nil {
+	links := make([]uint32, page.BackwardLinkLength)
+	buf := make([]byte, int(page.BackwardLinkLength)*4)
+	if _, err := w.linkFile.ReadAt(buf, int64(page.BackwardLinkIndex)*4); err != nil {
 		return nil, err
 	}
-	err = binary.Read(w.linkFile, binary.LittleEndian, links)
-	if err != nil {
+	if err := binary.Read(bytes.NewReader(buf), binary.LittleEndian, &links); err != nil {
 		return nil, err
 	}
 	return links, nil


### PR DESCRIPTION
## Summary

- `forwardLinks` / `backwardLinks` が `Seek` + `Read` を使っており、並行リクエスト時にファイルカーソルが競合するバグを修正
- `ReadAt` はファイルカーソルを動かさないため並行安全
- `title()` は既に `ReadAt` を使っており、同じパターンに統一

## Test plan

- [ ] `go test ./internal/app/web/...` が通ること
- [ ] 経路検索が正常に動作すること（並行リクエスト時も含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)