### PR TITLE
Update frontend toolchain: tsconfig, package.json, gitignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,9 +1,9 @@
 .idea
+.git
 *.dat
-en/
-ja/
 build
 vendor
 web/dist
 web/node_modules
 web/.parcel-cache
+*.gz

--- a/.gitignore
+++ b/.gitignore
@@ -18,10 +18,12 @@
 
 # dep
 vendor/
+.pnpm-store/
 
 # Project files, like IntelliJ IDEA, VisualStudio Code, etc.
 .idea/
 *.iml
+.vscode/
 
 # Application
 cmd/web/assets/

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,6 +1,5 @@
 .DS_Store
 node_modules
-/.parcel-cache/
 /dist/
 
 # local env files

--- a/web/env.d.ts
+++ b/web/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,7 @@
   "name": "web",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "serve": "vite",
     "build": "pnpm run clean && vite build",
@@ -17,8 +18,10 @@
     "vue-router": "^5.0.6"
   },
   "devDependencies": {
-    "@types/node": "^18.16.19",
+    "@tsconfig/node24": "^24.0.4",
+    "@types/node": "^24.1.0",
     "@vitejs/plugin-vue": "^6.0.6",
+    "@vue/tsconfig": "^0.9.1",
     "oxfmt": "latest",
     "oxlint": "latest",
     "rimraf": "^6.1.3",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -21,12 +21,18 @@ importers:
         specifier: ^5.0.6
         version: 5.0.6(@vue/compiler-sfc@3.5.34)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
     devDependencies:
+      '@tsconfig/node24':
+        specifier: ^24.0.4
+        version: 24.0.4
       '@types/node':
-        specifier: ^18.16.19
-        version: 18.19.130
+        specifier: ^24.1.0
+        version: 24.12.4
       '@vitejs/plugin-vue':
         specifier: ^6.0.6
-        version: 6.0.6(vite@8.0.11(@types/node@18.19.130)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))
+        version: 6.0.6(vite@8.0.11(@types/node@24.12.4)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))
+      '@vue/tsconfig':
+        specifier: ^0.9.1
+        version: 0.9.1(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))
       oxfmt:
         specifier: latest
         version: 0.48.0
@@ -41,7 +47,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^8.0.11
-        version: 8.0.11(@types/node@18.19.130)(yaml@2.8.4)
+        version: 8.0.11(@types/node@24.12.4)(yaml@2.8.4)
       vue-tsc:
         specifier: ^3.2.8
         version: 3.2.8(typescript@5.9.3)
@@ -464,11 +470,14 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.18':
     resolution: {integrity: sha512-CUY5Mnhe64xQBGZEEXQ5WyZwsc1JU3vAZLIxtrsBt3LO6UOb+C8GunVKqe9sT8NeWb4lqSaoJtp2xo6GxT1MNw==}
 
+  '@tsconfig/node24@24.0.4':
+    resolution: {integrity: sha512-2A933l5P5oCbv6qSxHs7ckKwobs8BDAe9SJ/Xr2Hy+nDlwmLE1GhFh/g/vXGRZWgxBg9nX/5piDtHR9Dkw/XuA==}
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
-  '@types/node@18.19.130':
-    resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
+  '@types/node@24.12.4':
+    resolution: {integrity: sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==}
 
   '@vitejs/plugin-vue@6.0.6':
     resolution: {integrity: sha512-u9HHgfrq3AjXlysn0eINFnWQOJQLO9WN6VprZ8FXl7A2bYisv3Hui9Ij+7QZ41F/WYWarHjwBbXtD7dKg3uxbg==}
@@ -547,6 +556,17 @@ packages:
 
   '@vue/shared@3.5.34':
     resolution: {integrity: sha512-24uqU4OIiX29ryC3MeWid/Xf2fa2EFRUVLb77nRhk+UrTVrh/XiGtFAFmJBAtBRbjwNdsPRP+jj/OL27Eg1NDA==}
+
+  '@vue/tsconfig@0.9.1':
+    resolution: {integrity: sha512-buvjm+9NzLCJL29KY1j1991YYJ5e6275OiK+G4jtmfIb+z4POywbdm0wXusT9adVWqe0xqg70TbI7+mRx4uU9w==}
+    peerDependencies:
+      typescript: '>= 5.8'
+      vue: ^3.4.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      vue:
+        optional: true
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -866,8 +886,8 @@ packages:
   ufo@1.6.4:
     resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+  undici-types@7.16.0:
+    resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
   unplugin-utils@0.3.1:
     resolution: {integrity: sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==}
@@ -1218,19 +1238,21 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.18': {}
 
+  '@tsconfig/node24@24.0.4': {}
+
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@types/node@18.19.130':
+  '@types/node@24.12.4':
     dependencies:
-      undici-types: 5.26.5
+      undici-types: 7.16.0
 
-  '@vitejs/plugin-vue@6.0.6(vite@8.0.11(@types/node@18.19.130)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))':
+  '@vitejs/plugin-vue@6.0.6(vite@8.0.11(@types/node@24.12.4)(yaml@2.8.4))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.13
-      vite: 8.0.11(@types/node@18.19.130)(yaml@2.8.4)
+      vite: 8.0.11(@types/node@24.12.4)(yaml@2.8.4)
       vue: 3.5.34(typescript@5.9.3)
 
   '@volar/language-core@2.4.28':
@@ -1351,6 +1373,11 @@ snapshots:
       vue: 3.5.34(typescript@5.9.3)
 
   '@vue/shared@3.5.34': {}
+
+  '@vue/tsconfig@0.9.1(typescript@5.9.3)(vue@3.5.34(typescript@5.9.3))':
+    optionalDependencies:
+      typescript: 5.9.3
+      vue: 3.5.34(typescript@5.9.3)
 
   acorn@8.16.0: {}
 
@@ -1647,7 +1674,7 @@ snapshots:
 
   ufo@1.6.4: {}
 
-  undici-types@5.26.5: {}
+  undici-types@7.16.0: {}
 
   unplugin-utils@0.3.1:
     dependencies:
@@ -1660,7 +1687,7 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  vite@8.0.11(@types/node@18.19.130)(yaml@2.8.4):
+  vite@8.0.11(@types/node@24.12.4)(yaml@2.8.4):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -1668,7 +1695,7 @@ snapshots:
       rolldown: 1.0.0-rc.18
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 18.19.130
+      '@types/node': 24.12.4
       fsevents: 2.3.3
       yaml: 2.8.4
 

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,7 +1,0 @@
-/// <reference types="vite/client" />
-
-declare module '*.vue' {
-  import type { DefineComponent } from 'vue';
-  const component: DefineComponent<{}, {}, any>;
-  export default component;
-}

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -1,0 +1,18 @@
+{
+  "extends": "@vue/tsconfig/tsconfig.dom.json",
+  "include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
+  "exclude": ["src/**/__tests__/*"],
+  "compilerOptions": {
+    // Extra safety for array and object lookups, but may have false positives.
+    "noUncheckedIndexedAccess": true,
+
+    // Path mapping for cleaner imports.
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+
+    // `vue-tsc --build` produces a .tsbuildinfo file for incremental type-checking.
+    // Specified here to keep it out of the root directory.
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo"
+  }
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,18 +1,11 @@
 {
-  "compilerOptions": {
-    "target": "es2016",
-    "module": "esnext",
-    "strict": true,
-    "skipLibCheck": true,
-    "jsx": "preserve",
-    "moduleResolution": "bundler",
-    "experimentalDecorators": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "sourceMap": true,
-    "lib": ["esnext", "dom"]
-  },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue", "tests/**/*.ts", "tests/**/*.tsx"],
-  "exclude": ["node_modules"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.node.json"
+    },
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ]
 }

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -1,9 +1,23 @@
+// TSConfig for modules that run in Node.js environment via either transpilation or type-stripping.
 {
+  "extends": "@tsconfig/node24/tsconfig.json",
+  "include": [
+    "vite.config.*",
+  ],
   "compilerOptions": {
-    "composite": true,
-    "module": "ESNext",
+    // Most tools use transpilation instead of Node.js's native type-stripping.
+    // Bundler mode provides a smoother developer experience.
+    "module": "preserve",
     "moduleResolution": "bundler",
-    "allowSyntheticDefaultImports": true
-  },
-  "include": ["vite.config.ts"]
+
+    // Include Node.js types and avoid accidentally including other `@types/*` packages.
+    "types": ["node"],
+
+    // Disable emitting output during `vue-tsc --build`, which is used for type-checking only.
+    "noEmit": true,
+
+    // `vue-tsc --build` produces a .tsbuildinfo file for incremental type-checking.
+    // Specified here to keep it out of the root directory.
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo"
+  }
 }


### PR DESCRIPTION
## Summary

- フロントエンドの TypeScript ビルド設定を create-vue テンプレートに合わせてリニューアル
- `@types/node` を v18 → v24 に更新、新規依存として `@vue/tsconfig` と `@tsconfig/node24` を追加
- 各種 `.gitignore` / `.dockerignore` の不要エントリを整理

## 変更詳細

### TypeScript 設定
- `tsconfig.json` を project references 形式にリファクタ — アプリ用 `tsconfig.app.json` とツール用 `tsconfig.node.json` に分離
- `tsconfig.app.json`: `@vue/tsconfig/tsconfig.dom.json` を継承、`noUncheckedIndexedAccess: true` を有効化
- `tsconfig.node.json`: `@tsconfig/node24/tsconfig.json` を継承、`module: "preserve"` + `moduleResolution: "bundler"` に統一
- `web/src/vite-env.d.ts` を削除し、create-vue 標準の `web/env.d.ts` に移行

### package.json / pnpm-lock.yaml
- `"type": "module"` を追加
- `@types/node` を `^18.16.19` → `^24.1.0` に更新
- `@vue/tsconfig ^0.9.1` と `@tsconfig/node24 ^24.0.4` を devDependencies に追加

### gitignore / dockerignore
- ルート `.gitignore`: `.pnpm-store/` と `.vscode/` を追加
- `web/.gitignore`: 使用をやめた `/.parcel-cache/` を削除
- `.dockerignore`: `.git` と `*.gz` を追加、不要になった `en/` `ja/` ディレクトリ指定を削除

## Test plan

- [ ] `pnpm install` が正常に完了すること
- [ ] `pnpm run build` でビルドエラーが出ないこと
- [ ] `vue-tsc --build` で型エラーが出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)