### PR TITLE
Fix docker build by specifying local build context

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v7
         with:
+          context: .
           file: build/package/app/Dockerfile
           push: true
           tags: mtgto/pediaroute:latest


### PR DESCRIPTION
## Summary

- `docker/build-push-action@v7` では `context` を指定しない場合、ローカルの checkout ではなくリモートの GitHub URL をビルドコンテキストとして使用する
- その際 HTTPS 認証ができず `fatal: could not read Username for 'https://github.com': terminal prompts disabled` エラーが発生していた
- `context: .` を明示することでローカルの checkout をコンテキストとして使用するよう修正

## Test plan

- [ ] CI の docker-build ジョブが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)