### PR TITLE
Add workflow_dispatch trigger to docker-build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,10 +6,11 @@ on:
     branches: [master]
     types:
       - completed
+  workflow_dispatch:
 
 jobs:
   docker-build:
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- `workflow_run` トリガーのみだと、docker-build.yml 自体を修正した際に再実行できない問題があった
- `workflow_dispatch` を追加し、手動実行できるようにした
- 手動実行時は CI チェックをバイパスするため、実行前に test/web ワークフローが green であることを確認する運用とする

## Test plan

- [ ] GitHub Actions UI から手動で docker-build ワークフローを実行できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)