### PR TITLE
Show green/red border on Field based on page title validity

### DIFF
--- a/web/src/components/Field.vue
+++ b/web/src/components/Field.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="field" :class="{ valid: isValid }">
+  <div class="field" :class="{ valid: isValid, invalid: isInvalid }">
     <div class="label">{{ label }}</div>
     <input class="input" v-bind="$attrs" v-model="model" @focus="onFocus" @blur="onBlur" @keydown="onKeydown" />
     <ul v-if="showDropdown" class="dropdown" role="listbox">
@@ -40,7 +40,9 @@ watch(
   },
 );
 
-const isValid = computed(() => !!model.value && !!props.suggestions?.some((s) => s.toLowerCase() === model.value.toLowerCase()));
+const isValid = computed(() => !!model.value && props.suggestions !== undefined && props.suggestions[0]?.toLowerCase() === model.value.toLowerCase());
+
+const isInvalid = computed(() => props.suggestions !== undefined && !!model.value && !isValid.value);
 
 const showDropdown = computed(() => {
   if (!isFocused.value || !props.suggestions?.length) return false;
@@ -90,6 +92,10 @@ const onSelect = (word: string) => {
 
 .valid {
   border-bottom-color: #3a7d44;
+}
+
+.invalid {
+  border-bottom-color: #b83232;
 }
 
 .label {

--- a/web/src/components/Field.vue
+++ b/web/src/components/Field.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="field">
+  <div class="field" :class="{ valid: isValid }">
     <div class="label">{{ label }}</div>
     <input class="input" v-bind="$attrs" v-model="model" @focus="onFocus" @blur="onBlur" @keydown="onKeydown" />
     <ul v-if="showDropdown" class="dropdown" role="listbox">
@@ -40,9 +40,11 @@ watch(
   },
 );
 
+const isValid = computed(() => !!model.value && !!props.suggestions?.some((s) => s.toLowerCase() === model.value.toLowerCase()));
+
 const showDropdown = computed(() => {
   if (!isFocused.value || !props.suggestions?.length) return false;
-  return !props.suggestions.some((s) => s.toLowerCase() === model.value.toLowerCase());
+  return !isValid.value;
 });
 
 const onFocus = () => {
@@ -83,6 +85,11 @@ const onSelect = (word: string) => {
   border-bottom: 1px solid var(--c-ink);
   padding-bottom: 8px;
   position: relative;
+  transition: border-color 0.2s;
+}
+
+.valid {
+  border-bottom-color: #3a7d44;
 }
 
 .label {

--- a/web/src/composables/useRelated.ts
+++ b/web/src/composables/useRelated.ts
@@ -4,15 +4,16 @@ import type { Ref } from 'vue';
 const cache = new Map<string, string[]>();
 
 export function useRelated(locale: Ref<string>) {
-  const suggestions = ref<string[]>([]);
+  const suggestions = ref<string[] | undefined>(undefined);
   let timer: ReturnType<typeof setTimeout> | null = null;
 
   const fetch = (word: string) => {
     if (timer) clearTimeout(timer);
     if ([...word].length < 2) {
-      suggestions.value = [];
+      suggestions.value = undefined;
       return;
     }
+    suggestions.value = undefined;
     const key = `${locale.value}:${word}`;
     const cached = cache.get(key);
     if (cached !== undefined) {
@@ -32,7 +33,7 @@ export function useRelated(locale: Ref<string>) {
   };
 
   const clear = () => {
-    suggestions.value = [];
+    suggestions.value = undefined;
   };
 
   onUnmounted(() => {


### PR DESCRIPTION
## Summary

- `useRelated` の `suggestions` を `string[] | undefined` に変更し、`undefined` で通信中・未検索、配列でAPI応答済みを表現
- 入力値が `suggestions[0]` と完全一致するとき緑のボーダーを表示（`RelatedPages` はアルファベット順で返すため、完全一致ページは必ず先頭に来る）
- API応答済みで一致しないとき（存在しないページ名）は赤のボーダーを表示

## Test plan

- [ ] 存在するページ名を入力すると緑枠になることを確認
- [ ] 存在しないページ名を入力すると赤枠になることを確認
- [ ] 入力中（デバウンス待ち・通信中）は黒枠のままであることを確認
- [ ] ランダムボタンで取得したページ名は緑枠になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)