### PR TITLE
Fix mobile overflow on submit button

### DIFF
--- a/web/src/views/Home.vue
+++ b/web/src/views/Home.vue
@@ -306,7 +306,6 @@ html.lang-ja .stats {
 
   .submit {
     text-align: center;
-    width: 100%;
   }
 }
 </style>


### PR DESCRIPTION
## Summary

- モバイル表示時に送信ボタンが画面からはみ出す問題を修正
- `.card-actions` の `align-items: stretch` が既にボタンを親幅いっぱいに伸ばしているため、`width: 100%` は冗長かつ `all: unset` による `box-sizing: content-box` と組み合わさってオーバーフローを引き起こしていた

## Test plan

- [ ] モバイル幅でホーム画面を開き、送信ボタンがはみ出さないことを確認
- [ ] デスクトップ幅での表示に変化がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)