### PR TITLE
Add GHA layer cache to docker-build workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,3 +26,5 @@ jobs:
           file: build/package/app/Dockerfile
           push: true
           tags: mtgto/pediaroute:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- `docker/build-push-action` に `cache-from: type=gha` / `cache-to: type=gha,mode=max` を追加
- `pnpm install` と `go mod download` のレイヤーがキャッシュされ、依存関係変更のないコミットでの再実行を省略
- `mode=max` でマルチステージビルドの中間ステージ（`asset`・`app`）も個別にキャッシュ

現状 53 秒かかっているビルドが、依存関係未変更のコミットで 10〜20 秒短縮される見込み。

## Test plan

- [ ] docker-build ワークフローが正常に完了すること
- [ ] 2回目以降の実行でキャッシュが効いて時間が短縮されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)