### PR TITLE
Add ServerError display for 5xx and network failures

### DIFF
--- a/web/src/components/Notice.vue
+++ b/web/src/components/Notice.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="notice">
     <div class="header">
-      <slot name="header-title" />
+      <span>{{ t('search.noticeTitle') }}</span>
       <span class="num">{{ num }}</span>
     </div>
-    <p :class="['body', bodyLarge && 'body--large']">
+    <p class="body body--large">
       <template v-if="errorCode === ErrorCode.ServerError">
         <i18n-t keypath="search.serverError">
           <template #em
@@ -12,27 +12,32 @@
           >
         </i18n-t>
       </template>
-      <slot v-else name="body" />
+      <template v-else>
+        <i18n-t keypath="search.notFoundBody">
+          <template #em
+            ><em class="notice-em">{{ t('search.notFoundBodyEm') }}</em></template
+          >
+        </i18n-t>
+      </template>
     </p>
-    <p v-if="$slots.note" class="note">
-      <slot name="note" />
+    <p v-if="errorCode === ErrorCode.NotFoundRoute" class="note">
+      {{ t('search.notFoundNote') }}
     </p>
   </div>
 </template>
 
 <script setup lang="ts">
 import { useI18n } from 'vue-i18n';
-import { ErrorCode, type ErrorCodeType } from '../types';
+import { ErrorCode } from '../types';
 
 const { t } = useI18n();
 
 withDefaults(
   defineProps<{
     num?: string;
-    bodyLarge?: boolean;
-    errorCode?: ErrorCodeType;
+    errorCode: typeof ErrorCode.NotFoundRoute | typeof ErrorCode.ServerError;
   }>(),
-  { num: '№ 0001 · v', bodyLarge: false },
+  { num: '№ 0001 · v' },
 );
 </script>
 

--- a/web/src/components/Notice.vue
+++ b/web/src/components/Notice.vue
@@ -5,7 +5,14 @@
       <span class="num">{{ num }}</span>
     </div>
     <p :class="['body', bodyLarge && 'body--large']">
-      <slot name="body" />
+      <template v-if="errorCode === ErrorCode.ServerError">
+        <i18n-t keypath="search.serverError">
+          <template #em
+            ><em class="notice-em">{{ t('search.serverErrorEm') }}</em></template
+          >
+        </i18n-t>
+      </template>
+      <slot v-else name="body" />
     </p>
     <p v-if="$slots.note" class="note">
       <slot name="note" />
@@ -14,10 +21,16 @@
 </template>
 
 <script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+import { ErrorCode, type ErrorCodeType } from '../types';
+
+const { t } = useI18n();
+
 withDefaults(
   defineProps<{
     num?: string;
     bodyLarge?: boolean;
+    errorCode?: ErrorCodeType;
   }>(),
   { num: '№ 0001 · v', bodyLarge: false },
 );
@@ -89,6 +102,10 @@ html.lang-ja .body--large {
 html.lang-ja .note {
   font-size: 14px;
   line-height: 1.9;
+}
+
+.notice-em {
+  color: var(--c-accent);
 }
 
 @media (max-width: 640px) {

--- a/web/src/components/SearchErrorNotice.vue
+++ b/web/src/components/SearchErrorNotice.vue
@@ -6,11 +6,7 @@
     </div>
     <p class="body body--large">
       <template v-if="errorCode === ErrorCode.ServerError">
-        <i18n-t keypath="search.serverError">
-          <template #em
-            ><em class="notice-em">{{ t('search.serverErrorEm') }}</em></template
-          >
-        </i18n-t>
+        {{ t('search.serverError') }}
       </template>
       <template v-else>
         <i18n-t keypath="search.notFoundBody">

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -68,8 +68,7 @@ export const i18n = createI18n({
         tryReverse: '↻ Try reverse',
         notFoundBody: 'No chain of {em} connects these two articles.',
         notFoundBodyEm: 'six links or fewer',
-        serverError: 'A {em} occurred. Please try again later.',
-        serverErrorEm: 'server error',
+        serverError: 'A server error occurred. Please try again later.',
         notFoundNote:
           'This usually means one of the titles is misspelled, or the goal article is a very isolated entry. PediaRoute caps the search at 6 hops on principle — longer chains tend to wander aimlessly across the encyclopedia.',
       },
@@ -158,8 +157,7 @@ export const i18n = createI18n({
         tryReverse: '逆方向を試す',
         notFoundBody: 'この二つの記事を{em}で結ぶ経路は見つかりませんでした。',
         notFoundBodyEm: '６リンク以内',
-        serverError: '{em}が発生しました。しばらく時間をおいてからお試しください。',
-        serverErrorEm: 'サーバーエラー',
+        serverError: 'サーバーエラーが発生しました。しばらく時間をおいてからお試しください。',
         notFoundNote:
           '記事名の表記揺れか、もしくは到着点が他から孤立した記事である可能性があります。PediaRoute は信念をもって探索を６歩までに留めています — それ以上長い経路は、百科事典を当てもなくさまようことになるため。',
       },

--- a/web/src/i18n.ts
+++ b/web/src/i18n.ts
@@ -68,6 +68,8 @@ export const i18n = createI18n({
         tryReverse: '↻ Try reverse',
         notFoundBody: 'No chain of {em} connects these two articles.',
         notFoundBodyEm: 'six links or fewer',
+        serverError: 'A {em} occurred. Please try again later.',
+        serverErrorEm: 'server error',
         notFoundNote:
           'This usually means one of the titles is misspelled, or the goal article is a very isolated entry. PediaRoute caps the search at 6 hops on principle — longer chains tend to wander aimlessly across the encyclopedia.',
       },
@@ -156,6 +158,8 @@ export const i18n = createI18n({
         tryReverse: '逆方向を試す',
         notFoundBody: 'この二つの記事を{em}で結ぶ経路は見つかりませんでした。',
         notFoundBodyEm: '６リンク以内',
+        serverError: '{em}が発生しました。しばらく時間をおいてからお試しください。',
+        serverErrorEm: 'サーバーエラー',
         notFoundNote:
           '記事名の表記揺れか、もしくは到着点が他から孤立した記事である可能性があります。PediaRoute は信念をもって探索を６歩までに留めています — それ以上長い経路は、百科事典を当てもなくさまようことになるため。',
       },

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,0 +1,8 @@
+export const ErrorCode = {
+  NoError: 0,
+  NotFoundFrom: 1,
+  NotFoundTo: 2,
+  NotFoundRoute: 3,
+  ServerError: 4,
+} as const;
+export type ErrorCodeType = (typeof ErrorCode)[keyof typeof ErrorCode];

--- a/web/src/views/Search.vue
+++ b/web/src/views/Search.vue
@@ -49,10 +49,7 @@
 
         <!-- Article not found -->
         <template v-else-if="errorCode === ErrorCode.NotFoundFrom || errorCode === ErrorCode.NotFoundTo">
-          <Notice>
-            <template #header-title>{{ t('search.noticeTitle') }}</template>
-            <template #body>{{ failureReason }}</template>
-          </Notice>
+          <p class="failure-reason">{{ failureReason }}</p>
           <div class="actions">
             <Button :as="RouterLink" variant="primary" to="/">
               {{ t('search.newSearchBack') }}
@@ -62,9 +59,7 @@
 
         <!-- Server error -->
         <template v-else-if="errorCode === ErrorCode.ServerError">
-          <Notice :body-large="true" :error-code="ErrorCode.ServerError">
-            <template #header-title>{{ t('search.noticeTitle') }}</template>
-          </Notice>
+          <Notice :error-code="ErrorCode.ServerError" />
           <div class="actions">
             <Button :as="RouterLink" variant="primary" to="/">
               {{ t('search.newSearchBack') }}
@@ -74,17 +69,7 @@
 
         <!-- Route not found -->
         <template v-else-if="errorCode === ErrorCode.NotFoundRoute">
-          <Notice :body-large="true">
-            <template #header-title>{{ t('search.noticeTitle') }}</template>
-            <template #body>
-              <i18n-t keypath="search.notFoundBody">
-                <template #em
-                  ><em class="notice-em">{{ t('search.notFoundBodyEm') }}</em></template
-                >
-              </i18n-t>
-            </template>
-            <template #note>{{ t('search.notFoundNote') }}</template>
-          </Notice>
+          <Notice :error-code="ErrorCode.NotFoundRoute" />
           <div class="actions">
             <Button :as="RouterLink" variant="primary" to="/">
               {{ t('search.newSearchBack') }}
@@ -285,9 +270,12 @@ html.lang-ja .result-label {
   flex-wrap: wrap;
 }
 
-/* Accent emphasis inside notice body slot */
-.notice-em {
-  color: var(--c-accent);
+.failure-reason {
+  font-family: var(--f-body);
+  font-size: 17px;
+  line-height: 1.6;
+  color: var(--c-ink);
+  margin-bottom: 36px;
 }
 
 /* Mobile */

--- a/web/src/views/Search.vue
+++ b/web/src/views/Search.vue
@@ -60,6 +60,18 @@
           </div>
         </template>
 
+        <!-- Server error -->
+        <template v-else-if="errorCode === ErrorCode.ServerError">
+          <Notice :body-large="true" :error-code="ErrorCode.ServerError">
+            <template #header-title>{{ t('search.noticeTitle') }}</template>
+          </Notice>
+          <div class="actions">
+            <Button :as="RouterLink" variant="primary" to="/">
+              {{ t('search.newSearchBack') }}
+            </Button>
+          </div>
+        </template>
+
         <!-- Route not found -->
         <template v-else-if="errorCode === ErrorCode.NotFoundRoute">
           <Notice :body-large="true">
@@ -98,19 +110,12 @@ import Button from '../components/Button.vue';
 import Notice from '../components/Notice.vue';
 import RouteList from '../components/RouteList.vue';
 import Stamp from '../components/Stamp.vue';
+import { ErrorCode, type ErrorCodeType } from '../types';
 
 const props = defineProps<{
   wordFrom: string;
   wordTo: string;
 }>();
-
-const ErrorCode = {
-  NoError: 0,
-  NotFoundFrom: 1,
-  NotFoundTo: 2,
-  NotFoundRoute: 3,
-} as const;
-type ErrorCodeType = (typeof ErrorCode)[keyof typeof ErrorCode];
 
 interface Result {
   readonly route: ReadonlyArray<string> | undefined;
@@ -141,16 +146,22 @@ const doSearch = async () => {
   const headers = { Accept: 'application/json', 'Content-Type': 'application/json' };
   const start = Date.now();
   return fetch(`/api/search?lang=${encodeURI(locale.value)}`, { method: 'POST', body, headers })
-    .then((r) => r.json())
-    .then((result: Result) => {
-      errorCode.value = result.error;
-      routes.value = result.route;
-      if (result.error === ErrorCode.NotFoundFrom) {
-        failureReason.value = t('error.notFoundFrom', { from: props.wordFrom });
-      } else if (result.error === ErrorCode.NotFoundTo) {
-        failureReason.value = t('error.notFoundTo', { to: props.wordTo });
+    .then((r) => {
+      if (r.status >= 500) {
+        errorCode.value = ErrorCode.ServerError;
+        time.value = Date.now() - start;
+        return;
       }
-      time.value = Date.now() - start;
+      return r.json().then((result: Result) => {
+        errorCode.value = result.error;
+        routes.value = result.route;
+        if (result.error === ErrorCode.NotFoundFrom) {
+          failureReason.value = t('error.notFoundFrom', { from: props.wordFrom });
+        } else if (result.error === ErrorCode.NotFoundTo) {
+          failureReason.value = t('error.notFoundTo', { to: props.wordTo });
+        }
+        time.value = Date.now() - start;
+      });
     })
     .finally(() => {
       isLoading.value = false;

--- a/web/src/views/Search.vue
+++ b/web/src/views/Search.vue
@@ -59,7 +59,7 @@
 
         <!-- Server error -->
         <template v-else-if="errorCode === ErrorCode.ServerError">
-          <Notice :error-code="ErrorCode.ServerError" />
+          <SearchErrorNotice :error-code="ErrorCode.ServerError" />
           <div class="actions">
             <Button :as="RouterLink" variant="primary" to="/">
               {{ t('search.newSearchBack') }}
@@ -69,7 +69,7 @@
 
         <!-- Route not found -->
         <template v-else-if="errorCode === ErrorCode.NotFoundRoute">
-          <Notice :error-code="ErrorCode.NotFoundRoute" />
+          <SearchErrorNotice :error-code="ErrorCode.NotFoundRoute" />
           <div class="actions">
             <Button :as="RouterLink" variant="primary" to="/">
               {{ t('search.newSearchBack') }}
@@ -92,7 +92,7 @@ import { ref, onMounted, watch } from 'vue';
 import { RouterLink } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import Button from '../components/Button.vue';
-import Notice from '../components/Notice.vue';
+import SearchErrorNotice from '../components/SearchErrorNotice.vue';
 import RouteList from '../components/RouteList.vue';
 import Stamp from '../components/Stamp.vue';
 import { ErrorCode, type ErrorCodeType } from '../types';
@@ -147,6 +147,10 @@ const doSearch = async () => {
         }
         time.value = Date.now() - start;
       });
+    })
+    .catch(() => {
+      errorCode.value = ErrorCode.ServerError;
+      time.value = Date.now() - start;
     })
     .finally(() => {
       isLoading.value = false;


### PR DESCRIPTION
## Summary

- `ErrorCode.ServerError` (code 4) を追加し、検索APIが5xxを返した場合・ネットワークエラーの場合に `SearchErrorNotice` を表示する
- `Notice.vue` を `SearchErrorNotice.vue` にリネーム。`errorCode` を必須 props (`NotFoundRoute | ServerError`) とし、表示内容をコンポーネント内部に集約。スロット廃止
- `ErrorCode` / `ErrorCodeType` を `src/types.ts` に抽出して共有化

## Test plan

- [ ] 正常系（経路あり・なし）が壊れていないことを確認
- [ ] バックエンドを停止した状態で検索し、`SearchErrorNotice` が表示されることを確認
- [ ] 日本語・英語それぞれで i18n テキストが正しく出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)