### PR TITLE
Use RUN --mount=type=cache/bind in Dockerfile and switch cache-to to mode=min

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -29,4 +29,4 @@ jobs:
           push: true
           tags: mtgto/pediaroute:latest
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=min

--- a/build/package/app/Dockerfile
+++ b/build/package/app/Dockerfile
@@ -1,21 +1,31 @@
+# syntax=docker/dockerfile:1
 
 # docker build --file build/package/app/Dockerfile --tag mtgto/pediaroute:latest .
 
 FROM node:24-trixie AS asset
 WORKDIR /node
-COPY web/package.json web/pnpm-lock.yaml /node/
-RUN corepack enable && pnpm install --frozen-lockfile
+RUN corepack enable
+RUN --mount=type=bind,source=web/package.json,target=package.json \
+    --mount=type=bind,source=web/pnpm-lock.yaml,target=pnpm-lock.yaml \
+    --mount=type=cache,target=/root/.local/share/pnpm/store,sharing=locked \
+    pnpm install --frozen-lockfile
 COPY web .
-RUN pnpm build
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
+    pnpm build
 
 FROM golang:1.26-trixie AS app
 WORKDIR /go/src/github.com/mtgto/pediaroute-go
+RUN --mount=type=cache,target=/go/pkg/mod/,sharing=locked \
+    --mount=type=bind,source=go.sum,target=go.sum \
+    --mount=type=bind,source=go.mod,target=go.mod \
+    go mod download -x
 COPY Makefile go.mod go.sum ./
-RUN go mod download
 COPY cmd ./cmd
 COPY --from=asset /node/dist ./cmd/web/assets
 COPY internal ./internal
-RUN make build/web
+RUN --mount=type=cache,target=/go/pkg/mod/ \
+    --mount=type=cache,target=/root/.cache/go-build \
+    make build/web
 
 FROM gcr.io/distroless/base-debian13
 WORKDIR /app


### PR DESCRIPTION
## Summary

- DockerfileでCOPY+RUNパターンを`--mount=type=bind`（依存ファイル）と`--mount=type=cache`（pnpm store・Goモジュールキャッシュ・Goビルドキャッシュ）に置き換え
- GHA側の`cache-to`を`mode=max`から`mode=min`に変更（`--mount=type=cache`があれば中間レイヤーキャッシュ不要なため、ストレージ節約）
- `# syntax=docker/dockerfile:1`プラグマを追加

## Test plan

- [ ] CIのdocker-buildワークフローが成功することを確認
- [ ] 2回目以降のビルドでキャッシュが効いて高速化されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)