### PR TITLE
Refactor Go code for idiomatic style and add staticcheck

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,5 +38,7 @@ jobs:
             ${{ runner.os }}-go-
       - name: vet
         run: mkdir -p cmd/web/assets && touch cmd/web/assets/dummy.txt && go vet ./...
+      - name: staticcheck
+        run: go tool staticcheck ./...
       - name: test
         run: make test

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -4,21 +4,18 @@ import (
 	"embed"
 	"encoding/json"
 	"flag"
-	"github.com/mtgto/pediaroute-go/internal/app/core"
-	"github.com/mtgto/pediaroute-go/internal/app/web"
 	"io/fs"
 	"log"
-	"math/rand"
 	"net/http"
 	"os"
-	"path"
+	"path/filepath"
 	"runtime"
-	"time"
+
+	"github.com/mtgto/pediaroute-go/internal/app/core"
+	"github.com/mtgto/pediaroute-go/internal/app/web"
 )
 
-/**
- * Error code of API
- */
+// Error code of API
 const (
 	NoError = iota
 	NotFoundFrom
@@ -30,7 +27,6 @@ const (
 var assets embed.FS
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
 	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
 	wikipedias := make(map[string]web.Wikipedia)
 
@@ -54,9 +50,9 @@ func main() {
 		if err != nil {
 			log.Fatalf("Failed to load language file: %v", err)
 		}
-		pageFile := path.Join(path.Dir(langFile), language.PageFile)
-		titleFile := path.Join(path.Dir(langFile), language.TitleFile)
-		linkFile := path.Join(path.Dir(langFile), language.LinkFile)
+		pageFile := filepath.Join(filepath.Dir(langFile), language.PageFile)
+		titleFile := filepath.Join(filepath.Dir(langFile), language.TitleFile)
+		linkFile := filepath.Join(filepath.Dir(langFile), language.LinkFile)
 		log.Printf("Start loading for language %v\n", language.Id)
 		wikipedia, err := web.Load(language.PageCount, pageFile, titleFile, linkFile)
 		if err != nil {
@@ -127,18 +123,18 @@ func main() {
 				}
 				w.Header().Set("Content-Type", "application/json")
 				if !wikipedia.IsWordExists(pair.From) {
-					result = SearchResult{nil, NotFoundFrom}
+					result = SearchResult{Route: nil, Error: NotFoundFrom}
 				} else if !wikipedia.IsWordExists(pair.To) {
-					result = SearchResult{nil, NotFoundTo}
+					result = SearchResult{Route: nil, Error: NotFoundTo}
 				} else {
 					log.Printf("Language: %v, Search from \"%v\" to \"%v\"\n", lang, pair.From, pair.To)
 					route := wikipedia.Search(pair.From, pair.To)
 					if route != nil {
 						log.Printf("Found a route: %v\n", route)
-						result = SearchResult{route, NoError}
+						result = SearchResult{Route: route, Error: NoError}
 					} else {
 						log.Printf("Not found a route from \"%v\" to \"%v\"\n", pair.From, pair.To)
-						result = SearchResult{nil, NotFoundRoute}
+						result = SearchResult{Route: nil, Error: NotFoundRoute}
 					}
 				}
 				err = json.NewEncoder(w).Encode(result)
@@ -209,9 +205,4 @@ func printMemory() {
 	var mem runtime.MemStats
 	runtime.ReadMemStats(&mem)
 	log.Printf("Memory: %+v", mem.HeapAlloc)
-}
-
-func isFileExists(file string) bool {
-	_, err := os.Stat(file)
-	return err == nil
 }

--- a/cmd/web/main.go
+++ b/cmd/web/main.go
@@ -138,6 +138,9 @@ func main() {
 					}
 				}
 				err = json.NewEncoder(w).Encode(result)
+				if err != nil {
+					log.Printf("Error while encoding json: %v\n", err)
+				}
 			} else {
 				http.Error(w, "Not Found", http.StatusNotFound)
 			}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
 
 require (
 	charm.land/lipgloss/v2 v2.0.3 // indirect
+	github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c // indirect
 	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.10.0 // indirect
 	github.com/briandowns/spinner v1.23.2 // indirect
@@ -52,13 +53,19 @@ require (
 	github.com/urfave/cli/v3 v3.8.0 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 // indirect
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.41.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
+	golang.org/x/tools v0.42.0 // indirect
+	honnef.co/go/tools v0.7.0 // indirect
 )
 
 go 1.26
 
-tool github.com/evilmartians/lefthook/v2
+tool (
+	github.com/evilmartians/lefthook/v2
+	honnef.co/go/tools/cmd/staticcheck
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 charm.land/lipgloss/v2 v2.0.3 h1:yM2zJ4Cf5Y51b7RHIwioil4ApI/aypFXXVHSwlM6RzU=
 charm.land/lipgloss/v2 v2.0.3/go.mod h1:7myLU9iG/3xluAWzpY/fSxYYHCgoKTie7laxk6ATwXA=
+github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c h1:pxW6RcqyfI9/kWtOwnv/G+AzdKuy2ZrqINhenH4HyNs=
+github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
@@ -115,6 +117,9 @@ go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
+golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa h1:FRnLl4eNAQl8hwxVVC17teOw8kdjVDVAiFMtgUdTSRQ=
+golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678 h1:1P7xPZEwZMoBoz0Yze5Nx2/4pxj6nw9ZqHWXqP0iRgQ=
+golang.org/x/exp/typeparams v0.0.0-20231108232855-2478ac86f678/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/mod v0.34.0 h1:xIHgNUUnW6sYkcM5Jleh05DvLOtwc6RitGHbDk4akRI=
 golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
@@ -134,3 +139,5 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogR
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+honnef.co/go/tools v0.7.0 h1:w6WUp1VbkqPEgLz4rkBzH/CSU6HkoqNLp6GstyTx3lU=
+honnef.co/go/tools v0.7.0/go.mod h1:pm29oPxeP3P82ISxZDgIYeOaf9ta6Pi0EWvCFoLG2vc=

--- a/internal/app/core/core.go
+++ b/internal/app/core/core.go
@@ -4,11 +4,10 @@ import (
 	"bufio"
 	"encoding/binary"
 	"encoding/json"
-	"log"
 	"os"
 )
 
-// WikipediaFiles defines JSON structure for data set of language.
+// Language defines JSON structure for data set of wikipediaPages.
 type Language struct {
 	Id        string `json:"id"`
 	PageCount uint32 `json:"page_count"`
@@ -38,37 +37,9 @@ func LoadPages(pageCount uint32, in string) []Page {
 	defer file.Close()
 	reader := bufio.NewReader(file)
 	pages := make([]Page, 0, pageCount)
-	for i := 0; uint32(i) < pageCount; i += 1 {
+	for i := 0; uint32(i) < pageCount; i++ {
 		page := Page{}
-		err := binary.Read(reader, binary.LittleEndian, &page.Id)
-		if err != nil {
-			panic(err)
-		}
-		err = binary.Read(reader, binary.LittleEndian, &page.TitleOffset)
-		if err != nil {
-			panic(err)
-		}
-		err = binary.Read(reader, binary.LittleEndian, &page.TitleLength)
-		if err != nil {
-			panic(err)
-		}
-		err = binary.Read(reader, binary.LittleEndian, &page.IsRedirect)
-		if err != nil {
-			panic(err)
-		}
-		err = binary.Read(reader, binary.LittleEndian, &page.ForwardLinkIndex)
-		if err != nil {
-			panic(err)
-		}
-		err = binary.Read(reader, binary.LittleEndian, &page.ForwardLinkLength)
-		if err != nil {
-			panic(err)
-		}
-		err = binary.Read(reader, binary.LittleEndian, &page.BackwardLinkIndex)
-		if err != nil {
-			panic(err)
-		}
-		err = binary.Read(reader, binary.LittleEndian, &page.BackwardLinkLength)
+		err := binary.Read(reader, binary.LittleEndian, &page)
 		if err != nil {
 			panic(err)
 		}
@@ -81,7 +52,7 @@ func LoadPages(pageCount uint32, in string) []Page {
 func LoadLanguage(in string) (*Language, error) {
 	bytes, err := os.ReadFile(in)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	language := Language{}
 	err = json.Unmarshal(bytes, &language)

--- a/internal/app/gen/gen.go
+++ b/internal/app/gen/gen.go
@@ -11,7 +11,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -50,13 +50,15 @@ func buildIndex[K cmp.Ordered](pages []page, keyFn func(page) K) []indexEntry[K]
 	for i, p := range pages {
 		idx[i] = indexEntry[K]{key: keyFn(p), index: uint32(i)}
 	}
-	sort.Slice(idx, func(i, j int) bool { return idx[i].key < idx[j].key })
+	slices.SortFunc(idx, func(a, b indexEntry[K]) int { return cmp.Compare(a.key, b.key) })
 	return idx
 }
 
 func lookupIndex[K cmp.Ordered](idx []indexEntry[K], key K) (uint32, bool) {
-	i := sort.Search(len(idx), func(k int) bool { return idx[k].key >= key })
-	if i < len(idx) && idx[i].key == key {
+	i, found := slices.BinarySearchFunc(idx, key, func(e indexEntry[K], k K) int {
+		return cmp.Compare(e.key, k)
+	})
+	if found {
 		return idx[i].index, true
 	}
 	return 0, false
@@ -191,15 +193,18 @@ func loadPages(in string) []page {
 		}
 	}
 	// Pre-compute lowercase once; O(N log N) comparisons would each allocate otherwise.
-	tmp := make([]struct {
+	type pageWithLower struct {
 		p     page
 		lower string
-	}, len(allPages))
+	}
+	tmp := make([]pageWithLower, len(allPages))
 	for i, p := range allPages {
 		tmp[i].p = p
 		tmp[i].lower = strings.ToLower(p.title)
 	}
-	sort.Slice(tmp, func(i, j int) bool { return tmp[i].lower < tmp[j].lower })
+	slices.SortFunc(tmp, func(a, b pageWithLower) int {
+		return cmp.Compare(a.lower, b.lower)
+	})
 	for i, t := range tmp {
 		allPages[i] = t.p
 	}
@@ -479,11 +484,11 @@ func generatePageLinks(in string, out string, pages []page, idIndex []indexEntry
 	defer fp.Close()
 	linkWriter := bufio.NewWriterSize(fp, 4*1024*1024)
 
-	sort.Slice(pairs, func(i, j int) bool {
-		if pairs[i].from != pairs[j].from {
-			return pairs[i].from < pairs[j].from
+	slices.SortFunc(pairs, func(a, b linkPair) int {
+		if a.from != b.from {
+			return cmp.Compare(a.from, b.from)
 		}
-		return pairs[i].to < pairs[j].to
+		return cmp.Compare(a.to, b.to)
 	})
 
 	var linkIndex uint32
@@ -502,11 +507,11 @@ func generatePageLinks(in string, out string, pages []page, idIndex []indexEntry
 		i = j
 	}
 
-	sort.Slice(pairs, func(i, j int) bool {
-		if pairs[i].to != pairs[j].to {
-			return pairs[i].to < pairs[j].to
+	slices.SortFunc(pairs, func(a, b linkPair) int {
+		if a.to != b.to {
+			return cmp.Compare(a.to, b.to)
 		}
-		return pairs[i].from < pairs[j].from
+		return cmp.Compare(a.from, b.from)
 	})
 
 	for i := 0; i < len(pairs); {

--- a/internal/app/gen/gen.go
+++ b/internal/app/gen/gen.go
@@ -7,15 +7,16 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"github.com/mtgto/pediaroute-go/internal/app/core"
-	"github.com/xwb1989/sqlparser"
 	"io"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/mtgto/pediaroute-go/internal/app/core"
+	"github.com/xwb1989/sqlparser"
 )
 
 type page struct {
@@ -70,8 +71,8 @@ func Run(languageId, pageSQLFile, pageLinkSQLFile, linktargetSQLFile, outDir, ve
 		Version:   version,
 	}
 	var pages []page
-	pageFile := path.Join(outDir, language.PageFile)
-	titleFile := path.Join(outDir, language.TitleFile)
+	pageFile := filepath.Join(outDir, language.PageFile)
+	titleFile := filepath.Join(outDir, language.TitleFile)
 	log.Printf("Load \"%s\".\n", pageSQLFile)
 	pages = loadPages(pageSQLFile)
 	language.PageCount = uint32(len(pages))
@@ -87,14 +88,14 @@ func Run(languageId, pageSQLFile, pageLinkSQLFile, linktargetSQLFile, outDir, ve
 		log.Printf("%d linktargets.\n", len(linktargets))
 	}
 
-	pageLinkFile := path.Join(outDir, language.LinkFile)
+	pageLinkFile := filepath.Join(outDir, language.LinkFile)
 	log.Printf("Create \"%s\".\n", pageLinkFile)
 	linkCount := generatePageLinks(pageLinkSQLFile, pageLinkFile, pages, idIndex, titleIndex, linktargets)
 	language.LinkCount = linkCount
 	log.Printf("%v links loaded.\n", language.LinkCount)
 	generatePages(pageFile, titleFile, pages)
 
-	configFile := path.Join(outDir, "config.json")
+	configFile := filepath.Join(outDir, "config.json")
 	configBytes, err := json.MarshalIndent(language, "", "  ")
 	if err != nil {
 		panic(err)
@@ -106,11 +107,8 @@ func Run(languageId, pageSQLFile, pageLinkSQLFile, linktargetSQLFile, outDir, ve
 	return nil
 }
 
-/**
- * Parse SQL insert statement of `pages` table.
- *
- * It returns pages which namespace == 0 (normal page)
- */
+// Parse SQL insert statement of `pages` table.
+// It returns pages which namespace == 0 (normal page)
 func parsePageStatement(stmt *sqlparser.Insert) ([]page, error) {
 	pages := make([]page, 0)
 	var columnIndex, pageID, pageNamespace, pageIsRedirect int

--- a/internal/app/web/web.go
+++ b/internal/app/web/web.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
-	"github.com/mtgto/pediaroute-go/internal/app/core"
 	"log"
 	"math/rand"
 	"os"
 	"sort"
 	"strings"
+
+	"github.com/mtgto/pediaroute-go/internal/app/core"
 )
 
 // Data structure
@@ -19,7 +20,7 @@ type Wikipedia struct {
 	linkFile  *os.File
 }
 
-var NotFound = errors.New("not found.")
+var ErrNotFound = errors.New("not found")
 
 const MaxDepth = 6
 
@@ -27,7 +28,7 @@ func (w *Wikipedia) Search(from, to string) []string {
 	start := w.generateWordSet(from)
 	goal := w.generateWordSet(to)
 	log.Printf("start: %v, goal: %v\n", start, goal)
-	way, err := w.search(&start, &goal, 0)
+	way, err := w.search(start, goal, 0)
 	if err != nil {
 		return nil
 	} else {
@@ -53,7 +54,7 @@ func (w *Wikipedia) IsWordExists(word string) bool {
 func (w *Wikipedia) IsWordRedirect(word string) bool {
 	indices := w.generateWordSet(word)
 	if len(indices) > 0 {
-		for index, _ := range indices {
+		for index := range indices {
 			if !w.pages[index].IsRedirect {
 				return false
 			}
@@ -101,7 +102,7 @@ func (w *Wikipedia) RelatedPages(word string, limit int) ([]string, error) {
 
 func (w *Wikipedia) generateWordSet(word string) map[uint32]struct{} {
 	lowercaseWord := strings.ToLower(word)
-	set := make(map[uint32]struct{}, 0)
+	set := make(map[uint32]struct{})
 	index := sort.Search(len(w.pages), func(i int) bool {
 		title, err := w.title(w.pages[i])
 		if err != nil {
@@ -112,7 +113,7 @@ func (w *Wikipedia) generateWordSet(word string) map[uint32]struct{} {
 	if index == len(w.pages) {
 		return set
 	}
-	for i := index; i >= 0; i -= 1 {
+	for i := index; i >= 0; i-- {
 		title, err := w.title(w.pages[i])
 		if err != nil {
 			log.Printf("Error while generateWordSet: %v", err)
@@ -124,7 +125,7 @@ func (w *Wikipedia) generateWordSet(word string) map[uint32]struct{} {
 			break
 		}
 	}
-	for i := index + 1; i < len(w.pages); i += 1 {
+	for i := index + 1; i < len(w.pages); i++ {
 		title, err := w.title(w.pages[i])
 		if err != nil {
 			log.Printf("Error while generateWordSet: %v", err)
@@ -139,27 +140,27 @@ func (w *Wikipedia) generateWordSet(word string) map[uint32]struct{} {
 	return set
 }
 
-func (w *Wikipedia) search(start, goal *map[uint32]struct{}, depth int) ([]uint32, error) {
+func (w *Wikipedia) search(start, goal map[uint32]struct{}, depth int) ([]uint32, error) {
 	if depth >= MaxDepth {
-		return nil, NotFound
+		return nil, ErrNotFound
 	}
-	if len(*start) < len(*goal) {
-		nextStarts := make(map[uint32]struct{}, 0)
-		for from, _ := range *start {
+	if len(start) < len(goal) {
+		nextStarts := make(map[uint32]struct{})
+		for from := range start {
 			links, err := w.forwardLinks(w.pages[from])
 			if err != nil {
 				return nil, err
 			}
 			for _, to := range links {
 				toIndex := to
-				if _, ok := (*goal)[toIndex]; ok {
+				if _, ok := goal[toIndex]; ok {
 					return []uint32{from, toIndex}, nil
 				} else {
 					nextStarts[toIndex] = struct{}{}
 				}
 			}
 		}
-		way, err := w.search(&nextStarts, goal, depth+1)
+		way, err := w.search(nextStarts, goal, depth+1)
 		if err != nil {
 			return nil, err
 		}
@@ -169,13 +170,13 @@ func (w *Wikipedia) search(start, goal *map[uint32]struct{}, depth int) ([]uint3
 		}
 		for _, from := range links {
 			fromIndex := from
-			if _, ok := (*start)[fromIndex]; ok {
+			if _, ok := start[fromIndex]; ok {
 				return append([]uint32{fromIndex}, way...), nil
 			}
 		}
 	} else {
-		nextGoals := make(map[uint32]struct{}, 0)
-		for to, _ := range *goal {
+		nextGoals := make(map[uint32]struct{})
+		for to := range goal {
 			links, err := w.backwardLinks(w.pages[to])
 			if err != nil {
 				log.Printf("err: %v\n", err)
@@ -183,14 +184,14 @@ func (w *Wikipedia) search(start, goal *map[uint32]struct{}, depth int) ([]uint3
 			}
 			for _, from := range links {
 				fromIndex := from
-				if _, ok := (*start)[fromIndex]; ok {
+				if _, ok := start[fromIndex]; ok {
 					return []uint32{fromIndex, to}, nil
 				} else {
 					nextGoals[fromIndex] = struct{}{}
 				}
 			}
 		}
-		way, err := w.search(start, &nextGoals, depth+1)
+		way, err := w.search(start, nextGoals, depth+1)
 		if err != nil {
 			return nil, err
 		}
@@ -200,12 +201,12 @@ func (w *Wikipedia) search(start, goal *map[uint32]struct{}, depth int) ([]uint3
 		}
 		for _, to := range links {
 			toIndex := to
-			if _, ok := (*goal)[toIndex]; ok {
+			if _, ok := goal[toIndex]; ok {
 				return append(way, toIndex), nil
 			}
 		}
 	}
-	return nil, NotFound
+	return nil, ErrNotFound
 }
 
 func (w *Wikipedia) forwardLinks(page core.Page) ([]uint32, error) {
@@ -233,14 +234,10 @@ func (w *Wikipedia) backwardLinks(page core.Page) ([]uint32, error) {
 }
 
 func (w *Wikipedia) title(page core.Page) (string, error) {
-	_, err := w.titleFile.Seek(int64(page.TitleOffset), 0)
+	buf := make([]byte, page.TitleLength)
+	_, err := w.titleFile.ReadAt(buf, int64(page.TitleOffset))
 	if err != nil {
 		return "", err
 	}
-	bytes := make([]byte, page.TitleLength)
-	_, err = w.titleFile.ReadAt(bytes, int64(page.TitleOffset))
-	if err != nil {
-		return "", err
-	}
-	return string(bytes), nil
+	return string(buf), nil
 }

--- a/internal/app/web/web.go
+++ b/internal/app/web/web.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"math/rand"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/mtgto/pediaroute-go/internal/app/core"
@@ -78,12 +78,13 @@ func (w *Wikipedia) GetRandomPage() (string, error) {
 
 func (w *Wikipedia) RelatedPages(word string, limit int) ([]string, error) {
 	lowerWord := strings.ToLower(word)
-	index := sort.Search(len(w.pages), func(i int) bool {
-		t, err := w.title(w.pages[i])
+	index, _ := slices.BinarySearchFunc(w.pages, lowerWord, func(p core.Page, target string) int {
+		t, err := w.title(p)
 		if err != nil {
 			log.Printf("Error while RelatedPages: %v", err)
+			return -1
 		}
-		return strings.ToLower(t) >= lowerWord
+		return strings.Compare(strings.ToLower(t), target)
 	})
 	results := make([]string, 0, limit)
 	for i := index; i < len(w.pages) && len(results) < limit; i++ {
@@ -103,12 +104,13 @@ func (w *Wikipedia) RelatedPages(word string, limit int) ([]string, error) {
 func (w *Wikipedia) generateWordSet(word string) map[uint32]struct{} {
 	lowercaseWord := strings.ToLower(word)
 	set := make(map[uint32]struct{})
-	index := sort.Search(len(w.pages), func(i int) bool {
-		title, err := w.title(w.pages[i])
+	index, _ := slices.BinarySearchFunc(w.pages, lowercaseWord, func(p core.Page, target string) int {
+		title, err := w.title(p)
 		if err != nil {
 			log.Printf("Error while generateWordSet: %v", err)
+			return -1
 		}
-		return strings.ToLower(title) >= lowercaseWord
+		return strings.Compare(strings.ToLower(title), target)
 	})
 	if index == len(w.pages) {
 		return set


### PR DESCRIPTION
## Summary

- Goの慣用的なスタイルへのリファクタリング（`ErrNotFound` 命名規則、`*map` → 値渡し、`filepath.Join`、`i++` スタイル等）
- `log.Fatal` と error return の混在を修正、不要な `Seek` / デッドコード削除
- `staticcheck` を `go tool` で導入し CI ワークフローに追加
- `sort` パッケージを `slices.SortFunc` / `slices.BinarySearchFunc` へ置き換え（Go 1.21+ のモダンな API）

## Test plan

- [ ] `go vet ./...` が通ること
- [ ] `go tool staticcheck ./...` が通ること
- [ ] `make test` が通ること
- [ ] CI (GitHub Actions) が全ステップ green になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)