### PR TITLE
Switch Docker image registry from Docker Hub to AWS Public ECR

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,21 +12,28 @@ jobs:
   docker-build:
     if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
-      - name: Login to DockerHub
-        uses: docker/login-action@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          role-to-assume: arn:aws:iam::698568974403:role/github-pediaroute
+          aws-region: us-east-1
+      - name: Login to Amazon ECR Public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
       - name: Build and push
         uses: docker/build-push-action@v7
         with:
           context: .
           file: build/package/app/Dockerfile
           push: true
-          tags: mtgto/pediaroute:latest
+          tags: public.ecr.aws/z3q0e2c8/pediaroute:latest
           cache-from: type=gha
           cache-to: type=gha,mode=min


### PR DESCRIPTION
## Summary

- Docker Hub (`mtgto/pediaroute`) から AWS Public ECR (`public.ecr.aws/z3q0e2c8/pediaroute`) へレジストリを移行
- OIDC による AssumeRole (`arn:aws:iam::698568974403:role/github-pediaroute`) で認証
- `permissions: id-token: write` を追加（OIDC トークン生成に必要）
- `timeout-minutes: 10` を追加

## Test plan

- [ ] ワークフローが正常に完了することを確認
- [ ] Public ECR にイメージが push されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)